### PR TITLE
Fixed example typo

### DIFF
--- a/CSV_XS.pm
+++ b/CSV_XS.pm
@@ -2827,7 +2827,7 @@ If  C<headers>  is an anonymous list,  the entries in the list will be used
 instead
 
  my $aoh = csv (in => $fh, headers => [qw( Foo Bar )]);
- csv (in => $aoa, out => $fh, headers => [qw( code description price }]);
+ csv (in => $aoa, out => $fh, headers => [qw( code description price )]);
 
 If C<headers> is an hash reference, this implies C<auto>, but header fields
 for that exist as key in the hashref will be replaced by the value for that


### PR DESCRIPTION
Fixed the type in the example of how to use headers with the functional approach.  The code will now run.