### PR TITLE
Add an example of how to write a CSV in memory using print().

### DIFF
--- a/CSV_XS.pm
+++ b/CSV_XS.pm
@@ -1312,6 +1312,17 @@ Text::CSV_XS - comma-separated values manipulation routines
  $csv->say ($fh, $_) for @rows;
  close $fh or die "new.csv: $!";
 
+ # Write a CSV in memory using print()
+ my $csv = Text::CSV_XS->new( { binary => 1, auto_diag => 2, eol => "\r\n" } );
+ my $file;
+ open my $fh, '>', \$file;
+
+ my @foo = map { [ 0 .. 5 ] } 0 .. 3;
+
+ for my $line ( @foo ) {
+     $csv->print( $fh, $line );
+ }
+
 =head1 DESCRIPTION
 
 Text::CSV_XS  provides facilities for the composition  and decomposition of


### PR DESCRIPTION
I spent a fair amount of time today scouring the docs on the most succinct way to create a CSV in memory.

I eventually came up with:

```perl
use IO::Scalar   ();
use Text::CSV_XS ();

my $csv = Text::CSV_XS->new( { binary => 1, auto_diag => 2 } );
my $file = IO::Scalar->new;

my @foo = map { [ 0 .. 5 ] } 0 .. 3;

for my $line ( @foo ) {
    $csv->combine( @$line );
    $csv->say( $file, [$csv->string] );
}
```

but @oschwald came up with a much more succinct example, which I've added via this pull request.

It would be nice to have *something* like this in the SYNOPSIS since it seems a bit non-obvious at this point.  I've used this module off and on for years and I'm constantly looking at the docs again and apparently not seeing things.  ;)

At any rate, if this isn't acceptable, maybe there's some other place to document this.  

Unrelated, I believe our paths will be crossing later next month???