### PR TITLE
Add missing flag references to the defaults list

### DIFF
--- a/CSV_XS.pm
+++ b/CSV_XS.pm
@@ -2253,6 +2253,8 @@ is equivalent to
      quote                 => undef,
      escape_char           => '"',
      binary                => 0,
+     strict                => 0,
+     formula               => 0,
      decode_utf8           => 1,
      auto_diag             => 0,
      diag_verbose          => 0,


### PR DESCRIPTION
A trivial fix to add two missing references to flags in the documentation's list of defaults. (I happened to be reading the documentation today and was looking at "strict", since it's a very handy feature.)