### PR TITLE
Fix the number of tests to skip, which varies depending on the value of $enc

### DIFF
--- a/t/85_util.t
+++ b/t/85_util.t
@@ -14,7 +14,7 @@ BEGIN {
         plan skip_all => "This test unit requires perl-5.8.2 or higher";
         }
     else {
-	my $n = 1370;
+	my $n = 1442;
 	$pu and $n -= 120;
 	plan tests => $n;
 	}
@@ -277,7 +277,7 @@ foreach my $irs ("\n", "\xaa") {
 	    $csv = Text::CSV_XS->new ({ binary => 1, auto_diag => 9 });
 
 	    SKIP: {
-		$has_enc or skip "Encoding $enc not supported", 7;
+		$has_enc or skip "Encoding $enc not supported", $enc =~ /^utf/ ? 10 : 9;
 		$csv->column_names (undef);
 		open my $fh, "<", $fnm;
 		binmode $fh;


### PR DESCRIPTION
I've got a report from Andreas that the latest Text::CSV was broken under Perl 5.8.4 because of the incorrect test plan (cf http://www.cpantesters.org/cpan/report/e65245fc-0e09-11e9-99de-cfe2e2691208). It seems that one of the numbers of tests to skip in t/85_util.t is wrong (9 or 10, depending on the vlaue of $enc), and so is the whole test plan because of that.