### PR TITLE
Escape nested delimiters

### DIFF
--- a/CSV_XS.pm
+++ b/CSV_XS.pm
@@ -844,7 +844,7 @@ sub header {
 	    %args = %$_;
 	    next;
 	    }
-	croak (q{usage: $csv->header ($fh, [ seps ], { options })});
+	croak (q{usage: $csv->header ($fh, [ seps ], \{ options \})});
 	}
 
     defined $args{'munge'} && !defined $args{'munge_column_names'} and


### PR DESCRIPTION
Perl does a balancing act (literally) to support nested delimiters. However, the parsing is simpler when all characters which act as delimiters are escaped.

Even editor highlighters can get confused because unless they implement delimiter balancing to accommodate them being delimiters and quoted characters at the same time.