### PR TITLE
Expressions with comma or fat comma should be inside parens:

### DIFF
--- a/CSV_XS.pm
+++ b/CSV_XS.pm
@@ -169,7 +169,7 @@ sub new {
     my %attr  = map {
 	my $k = m/^[a-zA-Z]\w+$/ ? lc $_ : $_;
 	exists $attr_alias{$k} and $k = $attr_alias{$k};
-	$k => $attr->{$_};
+	( $k => $attr->{$_} );
 	} keys %$attr;
 
     my $sep_aliased = 0;


### PR DESCRIPTION
perl looks for a comma within a block to disambiguate between a hashref and a block. It is also difficult to determine by humans unless there's enough code. Both can get it wrong and do.

The following is a good way to prevent ambiguous syntax:

    map {   $_ => 0   } @a; # not ok - fat comma, no parens
    map { ( $_ => 0 ) } @a; # ok - fat comma, parens

This subroutine has a top-level statement with braces and a fat
comma. It can be a block or a hashref.

    sub foo { { 1 => 2 } }        # not ok

It's hard to tell so it should be diambiguated by somehting:

    sub foo { return { 1 => 2 } } # ok - disambiguated with "return"

The following is the same problem:

    sub foo { 1 => 2 } # not ok

We can fix it with:

    sub foo { ( 1 => 2 ) } # ok

This, the rule is:

* Use parens around all expressions with comma or fat-comma, if not inside an expression.
* Comma and fat comma shouldn't be used in top-level operators in blocks
  * `sub foo { 1, 2 }` is confusing syntax
  * This avoids the need for perl's disambiguation rules that look for comma inside the braces.