### PR TITLE
fix skip_empty_rows('skip') and trailing newlines

### DIFF
--- a/CSV_XS.xs
+++ b/CSV_XS.xs
@@ -974,7 +974,7 @@ static char *cx_formula (pTHX_ csv_t *csv, SV *sv, STRLEN *len, int f) {
 	if (c == EOF || ser == 2) {					\
 	    sv_free (sv);						\
 	    sv = NULL;							\
-	    waitingForField = 0;					\
+	    seenSomething = 0;					\
 	    if (ser == 2) return FALSE;					\
 	    break;							\
 	    }								\

--- a/t/67_emptrow.t
+++ b/t/67_emptrow.t
@@ -10,7 +10,7 @@ BEGIN {
         plan skip_all => "This test unit requires perl-5.8.1 or higher";
 	}
     else {
-	plan tests => 47;
+	plan tests => 56;
 	}
 
     use_ok "Text::CSV_XS", ("csv");
@@ -89,6 +89,14 @@ is_deeply (csv (@parg, skip_empty_rows => sub {\@repl}), [ @head,
     $ea,[8,2,7,1],$ea,$ea,[5,7,9,3],$ea],			"A Callback");
 is_deeply (csv (@parg, skip_empty_rows => sub {0}), \@head,	"A Callback 0");
 
+# Array behavior (line by line)
+open $fh, "<", $tfn;
+$csv = Text::CSV_XS->new ({ skip_empty_rows => 1 });
+while (my $row = $csv->getline($fh)) {
+    ok (@$row)
+}
+close $fh;
+
 # Hash behavior
 push @parg => bom => 1;
 my $eh = { a => "", b => undef, c => undef, d => undef },
@@ -122,3 +130,13 @@ is_deeply (csv (@parg, skip_empty_rows => sub {\@repl}), [ @head, $eh,
     { a => 5, b => 7, c => 9, d => 3 },$eh],			"H Callback");
 
 is_deeply (csv (@parg, skip_empty_rows => sub {0}), \@head,	"H Callback 0");
+
+# Hash behavior (line by line)
+open $fh, "<", $tfn;
+$csv = Text::CSV_XS->new ({ skip_empty_rows => 1 });
+my $cols = $csv->getline($fh);
+$csv->column_names(@$cols);
+while (my $row = $csv->getline_hr($fh)) {
+    isnt ($row->{a}, undef);
+}
+close $fh;


### PR DESCRIPTION
When reading line by line, Text::CSV_XS returns an empty row if the input file contains an empty line, even if skip_empty_rows('skip') is in use.

The mechanism for this is substantially the same as is decribed in the corresponding PR for Text::CSV:
https://github.com/makamaka/Text-CSV/pull/65

This fixes:
https://github.com/Tux/Text-CSV_XS/issues/51